### PR TITLE
bump checkout package to v4 because of deprecated nodeJS version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ jobs:
     name: Gitlab Sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: action-pack/gitlab-sync@v3


### PR DESCRIPTION
NodeJS 12 is deprecated in Github Actions and will forced to v16 in the next time